### PR TITLE
Add redirect for "Add-ons Support" page (FAQ)

### DIFF
--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -94,6 +94,8 @@ apache_vhosts:
       RewriteEngine On
       RewriteCond %{HTTP:X-Forwarded-Proto} ^http$
       RewriteRule ^.*$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301,NE]
+      RewriteCond %{REQUEST_URI} ^/thunderbird/([^/]+)/([^/]+)/([^/]+)/addons-help$
+      RewriteRule (.*) https://support.mozilla.org/kb/thunderbird-add-ons-frequently-asked-questions [L]
       RewriteCond %{REQUEST_URI} ^/thunderbird/([^/]+)/([^/]+)/([^/]+)/extension-permissions$
       RewriteRule (.*) https://support.mozilla.org/kb/permission-request-messages-thunderbird-extensions [L]
       RewriteCond %{REQUEST_URI} ^/kb/ask$


### PR DESCRIPTION
As stated in [Bug 1642219](https://bugzilla.mozilla.org/show_bug.cgi?id=1642219), we would like to re-activate (unhide) the "Add-ons Support" button in the Add-on manager:

![image](https://user-images.githubusercontent.com/5830621/107235574-18f55e80-6a25-11eb-9046-ba54d869250f.png)

That button links to
https://support.thunderbird.net/thunderbird/{appver}/{os}/{locale}/addons-help

This pull request adds a redirect to:
https://support.mozilla.org/kb/thunderbird-add-ons-frequently-asked-questions