### PR TITLE
Update apache.yml

### DIFF
--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -94,6 +94,8 @@ apache_vhosts:
       RewriteEngine On
       RewriteCond %{HTTP:X-Forwarded-Proto} ^http$
       RewriteRule ^.*$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301,NE]
+      RewriteCond %{REQUEST_URI} ^/thunderbird/([^/]+)/([^/]+)/([^/]+)/cant-remove-addon$
+      RewriteRule (.*) https://support.mozilla.org/kb/policies-extensions-locked [L]
       RewriteCond %{REQUEST_URI} ^/thunderbird/([^/]+)/([^/]+)/([^/]+)/addons-help$
       RewriteRule (.*) https://support.mozilla.org/kb/thunderbird-add-ons-frequently-asked-questions [L]
       RewriteCond %{REQUEST_URI} ^/thunderbird/([^/]+)/([^/]+)/([^/]+)/extension-permissions$


### PR DESCRIPTION
I added a KB page explaining why some add-ons cannot be removed from the UI, so we can link that to the link shown to the user.

See
https://bugzilla.mozilla.org/show_bug.cgi?id=1700279#c9

Link this will point to is
https://support.mozilla.org/kb/policies-extensions-locked

Edit: The Why? Link was not added by me, but has been part of the product for long.