### PR TITLE
Remove work-around for invalid data in ISPDB

### DIFF
--- a/files/update.sh
+++ b/files/update.sh
@@ -16,7 +16,6 @@ cd $DATA
 cp -R ../webroot/* $TEMP
 source /var/www/tbservices/bin/activate
 python ../tools/convert.py -a -d $TEMP/v1.1 *
-rm -rf $DATA/cloudnine-net.jp
 python ../tools/convert.py -a -d $TEMP/v1.0 -v 1.0 *
 
 mv $DEST $PURGEDIR


### PR DESCRIPTION
See https://github.com/thundernest/autoconfig/pull/46

This should only be merged after the change to the autoconfig repository has been merged.