### PR TITLE
Remove support for autoconfig v1.0

### DIFF
--- a/files/update.sh
+++ b/files/update.sh
@@ -10,13 +10,11 @@ DATA=/var/www/autoconfig.momo/ispdb
 # Make sure we regenerate all the files so deleted files don't stay.
 mkdir -p $TEMP
 mkdir -p $TEMP/v1.1
-mkdir -p $TEMP/v1.0
 
 cd $DATA
 cp -R ../webroot/* $TEMP
 source /var/www/tbservices/bin/activate
 python ../tools/convert.py -a -d $TEMP/v1.1 *
-python ../tools/convert.py -a -d $TEMP/v1.0 -v 1.0 *
 
 mv $DEST $PURGEDIR
 mv $TEMP $DEST

--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -57,7 +57,7 @@ apache_vhosts:
     documentroot: "/var/www/html/autoconfig.momo/"
     options: "+Indexes +FollowSymLinks"
     extra_parameters: |
-      <Location ~ "/v1(\.0|\.1)/">
+      <Location ~ "/v1\.1)/">
         Header set Access-Control-Allow-Origin "*"
         ForceType text/xml
       </Location>


### PR DESCRIPTION
@Sancus checked the logs and it looks like nobody is using ISPDB v1.0 anymore.