### PR TITLE
Add /donate and /newsletter as a WSGI script alias. (Fixes #34)

### DIFF
--- a/vars/apache.yml
+++ b/vars/apache.yml
@@ -172,8 +172,10 @@ apache_vhosts:
       # URLs with no language code need to be assigned one by wsgi.py
       WSGIScriptAliasMatch ^/$ /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/about[/]?$ /var/www/html/start/wsgi.py
+      WSGIScriptAliasMatch ^/donate /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/download /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/features[/]?$ /var/www/html/start/wsgi.py
+      WSGIScriptAliasMatch ^/newsletter /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/organizations[/]?$ /var/www/html/start/wsgi.py
       WSGIScriptAliasMatch ^/thunderbird /var/www/html/start/wsgi.py
       RewriteRule ^/calendar/?(.*)$ /en-US/calendar/$1 [R=302]


### PR DESCRIPTION
Without these aliases we can't link to www.thunderbird.net/donate or www.thunderbird.net/newsletter